### PR TITLE
Fix handlebars version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
   ],
   "dependencies": {
     "jquery": "~1.9.1",
-    "handlebars": "~1.0.0-rc.5"
+    "handlebars": "~1.0.0-rc.4"
   }
 }

--- a/component.json
+++ b/component.json
@@ -8,6 +8,6 @@
   ],
   "dependencies": {
     "component/jquery": "~1.9.1",
-    "components/handlebars.js": "~1.0.0-rc.5"
+    "components/handlebars.js": "~1.0.0-rc.4"
   }
 }


### PR DESCRIPTION
Handlebars 1.0.0-rc.5 does not exist (https://github.com/wycats/handlebars.js/tags) so I updated it back to 1.0.0-rc.4 which is the version of handlebars the ember starter-kit uses.
