### PR TITLE
Ember 1.0.0-rc.6.1 requires handlebars-1.0.0-rc.4.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
   ],
   "dependencies": {
     "jquery": "~1.9.1",
-    "handlebars": "1.0.0"
+    "handlebars": "1.0.0-rc.4"
   }
 }

--- a/component.json
+++ b/component.json
@@ -8,6 +8,6 @@
   ],
   "dependencies": {
     "component/jquery": "~1.9.1",
-    "components/handlebars.js": "1.0.0"
+    "components/handlebars.js": "1.0.0-rc.4"
   }
 }


### PR DESCRIPTION
`ember-1.0.0-rc.6.1` still requires handlebars `1.0.0-rc.4`. The only
changes from 1.0.0-rc.6.1 were security related.
