### PR TITLE
[Fixes #28] Relax jquery dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "./ember.js"
   ],
   "dependencies": {
-    "jquery": "~1.9.1",
+    "jquery": ">= 1.7",
     "handlebars": "1.0.0"
   }
 }

--- a/component.json
+++ b/component.json
@@ -7,7 +7,7 @@
     "ember.js"
   ],
   "dependencies": {
-    "component/jquery": "~1.9.1",
+    "component/jquery": ">= 1.7",
     "components/handlebars.js": "1.0.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "component",
     "license": "MIT",
     "require": {
-        "components/jquery": ">=1.9",
+        "components/jquery": ">=1.7",
         "components/handlebars.js": "1.*"
     },
     "extra": {


### PR DESCRIPTION
Relax the jquery dependency to 1.7 (smallest supported by ember)
