### PR TITLE
Update handlebars dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
   ],
   "dependencies": {
     "jquery": ">= 1.7",
-    "handlebars": "1.0.0"
+    "handlebars": ">= 1.0.0"
   }
 }


### PR DESCRIPTION
Handlebars is currently at 1.1.2 - this allows Ember to install the most recent version.
