### PR TITLE
Allow jQuery 2.1.0 (Fixes #50)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "./ember.js"
   ],
   "dependencies": {
-    "jquery": ">= 1.7 <= 2.1",
+    "jquery": ">= 1.7.0 <= 2.1.0",
     "handlebars": ">= 1.0.0 < 2.0.0"
   }
 }

--- a/component.json
+++ b/component.json
@@ -7,7 +7,7 @@
     "ember.js"
   ],
   "dependencies": {
-    "component/jquery": ">= 1.7 <= 2.1",
+    "component/jquery": ">= 1.7.0 <= 2.1.0",
     "components/handlebars.js": ">= 1.0.0 < 2.0.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "component",
     "license": "MIT",
     "require": {
-        "components/jquery": ">=1.7 <= 2.1",
+        "components/jquery": ">=1.7.0 <= 2.1.0",
         "components/handlebars.js": "1.*"
     },
     "extra": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": ["ember"],
   "main": "./ember.js",
   "dependencies": {
-    "jquery": ">=1.7 <= 2.1",
+    "jquery": ">=1.7.0 <= 2.1.0",
     "handlebars": ">= 1.0.0 < 2.0.0"
   }
 }


### PR DESCRIPTION
Because Bower is following `semver`, `2.1` is not ligher or equal than `2.1.0`. This PR changes all versions to follow `semver` and fixes #50.
