### PR TITLE
Allow  jQuery 2.1 patch releases

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "./ember.js"
   ],
   "dependencies": {
-    "jquery": ">= 1.7.0 <= 2.1.0",
+    "jquery": ">= 1.7.0 < 2.2.0",
     "handlebars": ">= 1.0.0 < 2.0.0"
   }
 }


### PR DESCRIPTION
Minor jQuery patch release 2.1.1 was released in May. It should be possible to use it without manual bower resolutions.
