### PR TITLE
Update jquery version to be less than 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": ["ember"],
   "main": "./ember.js",
   "dependencies": {
-    "jquery": ">=1.7.0 <= 2.1.0",
+    "jquery": ">=1.7.0 < 2.2.0",
     "handlebars": ">= 1.0.0 < 2.0.0"
   }
 }


### PR DESCRIPTION
With the current range `>=1.7.0 <= 2.1.0`, `jquery@2.1.1` is unmet. But I imagine ember would be just as compatible with `2.1.0` as any `2.1.x` patch version and thus `<= 2.1.0` should be `< 2.2.0` instead.

Thanks!
