### PR TITLE
Fix jQuery repo in component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,7 +7,7 @@
     "ember.js"
   ],
   "dependencies": {
-    "component/jquery": ">= 1.7.0 <= 2.1.0",
+    "components/jquery": ">= 1.7.0 <= 2.1.0",
     "components/handlebars.js": ">= 1.0.0 < 2.0.0"
   }
 }


### PR DESCRIPTION
The jQuery dependency in component.json is pointing at the wrong repository. This causes Component (and Duo) to fail when they try to install `components/ember`. Changing the dependency from `component/jquery` to `components/jquery` fixes the problem.

`component install` still isn't working, but that seems to be because it can't handle the version range correctly. Duo works correctly.