### PR TITLE
jspm compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,19 @@
   "dependencies": {
     "jquery": ">=1.7.0 < 2.2.0",
     "handlebars": ">= 2.0.0 < 3.0.0"
+  },
+  "jspm": {
+    "main": "ember",
+    "shim": {
+      "ember": { "deps": ["jquery", "handlebars"], "exports": "Ember" },
+      "ember.prod": { "deps": ["jquery", "handlebars"], "exports": "Ember" }
+    },
+    "registry": "jspm",
+    "dependencies": {
+      "jquery": "github:components/jquery@^2.1.1",
+      "handlebars": "github:components/handlebars.js@^master"
+    },
+    "files": ["ember.js", "ember.prod.js"],
+    "buildConfig": { "minify": true }
   }
 }


### PR DESCRIPTION
This PR enables installation through jspm: `jspm install ember=github:components/ember`

Using it is quite easy: Type the command above and create these two files
``` HTML
<!-- index.html -->
<script src="jspm_packages/system.js"></script>
<script src="config.js"></script>
<script>
  System.import('main').catch(console.error.bind(console))
</script>
```

``` JavaScript
// main.js
import Ember from 'ember'
Ember.Application.create()
```