### PR TITLE
ember-template-engine added to main tag in Bower.json for wiredep errors.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,9 @@
   "name": "ember",
   "version": "1.12.0-beta.1",
   "main": [
-    "./ember.debug.js"
+    "./ember.debug.js",
+	"./ember-template-compiler.js"
+
   ],
   "dependencies": {
     "jquery": ">= 1.7.0 < 2.2.0"

--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,7 @@
   "version": "1.12.0-beta.1",
   "main": [
     "./ember.debug.js",
-	"./ember-template-compiler.js"
-
+    "./ember-template-compiler.js"
   ],
   "dependencies": {
     "jquery": ">= 1.7.0 < 2.2.0"


### PR DESCRIPTION
Added Ember Template Engine to Bower, WireDep plugin don't include this component if its not in main hence templates won't compile.

For templates compilation its required or it throws an error "Uncaught Error: Cannot call `compile` without the template compiler loaded. Please load `ember-template-compiler.js` prior to calling `compile`"