### PR TITLE
[DOCS] adding the license key to the bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "ember",
   "version": "2.1.0-beta.1",
+  "license": "MIT",
   "main": [
     "./ember.debug.js",
     "./ember-template-compiler.js"

--- a/component.json
+++ b/component.json
@@ -2,6 +2,7 @@
   "name": "ember",
   "repo": "components/ember",
   "version": "2.1.0-beta.1",
+  "license": "MIT",
   "main": "ember.debug.js",
   "scripts": [
     "ember.debug.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "components-ember",
   "version": "2.1.0-beta.1",
+  "license": "MIT",
   "description": "Ember Application Framework",
   "keywords": [
     "ember"


### PR DESCRIPTION
We are doing a security audit of all the dependencies in our bower.json. We are using the `bower-license` node module and it is searching the bower.json for the license key. This would allow us to programmatically show our security folks that we are using libraries with an acceptable license.

This would close #72.